### PR TITLE
install the configuration for the simplerules module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,8 @@ install(FILES conf/ulatencyd.conf
         DESTINATION ${CONFIG_PREFIX}/ulatencyd)
 install(FILES conf/cgroups.conf 
         DESTINATION ${CONFIG_PREFIX}/ulatencyd)
+install(FILES conf/simple.conf
+        DESTINATION ${CONFIG_PREFIX}/ulatencyd)
 install(DIRECTORY rules 
         DESTINATION ${CONFIG_PREFIX}/ulatencyd 
         FILES_MATCHING PATTERN "*.lua"


### PR DESCRIPTION
Not sure if this is intended or not, but the simple.conf file is not installed. Even if it is only comments, it may be useful for the user to learn how it can be used (and also to avoid the 'Failed to open file' error in the log :) )
