### PR TITLE
Added, updated & expanded default configs

### DIFF
--- a/conf/simple.d/audio.conf
+++ b/conf/simple.d/audio.conf
@@ -14,3 +14,8 @@ yauap                user.media
 ogg123               user.media
 cmus                 user.media
 lastfm               user.media
+beatbox              user.media
+noise                user.media
+aqualung             user.media
+audacious*           user.media
+guayadeque           user.media

--- a/conf/simple.d/bittorrent.conf
+++ b/conf/simple.d/bittorrent.conf
@@ -1,0 +1,22 @@
+# torrent clients, downloaders, all that stuff
+# TODO: find a way to do network scheduling
+#maybe Trickle will work for that...
+# I'm not completely sure what prio should I use for
+# such things... let them be daemons for now.
+
+# Multi-frontend
+transmission*                 daemon.bg
+deluge*                       daemon.bg
+# qbittorrent has Qt and command-line UIs
+qbittorrent*                  daemon.bg
+
+# GNOME/GTK
+flush                         daemon.bg
+gnome-btdownload              daemon.bg
+
+# KDE/Qt
+ktorrent                      daemon.bg
+
+# TODO: 
+#bittornado and vuze are missing,
+#because they use complicated name patterns.

--- a/conf/simple.d/dbus.conf
+++ b/conf/simple.d/dbus.conf
@@ -1,0 +1,6 @@
+# dbus-daemon powers interprocess communication, so it should be responsive.
+dbus-daemon                   user.bg_high  inherit=0
+
+#TODO:
+# Find out what do "dbus" processes do
+# Consider realtime privileges

--- a/conf/simple.d/dbus.conf
+++ b/conf/simple.d/dbus.conf
@@ -1,6 +1,2 @@
 # dbus-daemon powers interprocess communication, so it should be responsive.
 dbus-daemon                   user.bg_high  inherit=0
-
-#TODO:
-# Find out what do "dbus" processes do
-# Consider realtime privileges

--- a/conf/simple.d/gui-terminals.conf
+++ b/conf/simple.d/gui-terminals.conf
@@ -1,0 +1,11 @@
+# GUI terminals
+
+# the problem about them is that when they're set to
+# infinite line width, they may eat up all available RAM.
+
+gnome-terminal                user.poison   reason=memory   inherit=0
+pantheon-terminal             user.poison   reason=memory   inherit=0
+konsole                       user.poison   reason=memory   inherit=0
+yakuake                       user.poison   reason=memory   inherit=0
+evilvte                       user.poison   reason=memory   inherit=0
+guake                         user.poison   reason=memory   inherit=0

--- a/conf/simple.d/pantheon.conf
+++ b/conf/simple.d/pantheon.conf
@@ -1,0 +1,5 @@
+# Pantheon Shell
+
+plank                         user.ui
+wingpanel                     user.ui
+slingshot                     user.ui

--- a/conf/simple.d/screencasters.conf
+++ b/conf/simple.d/screencasters.conf
@@ -1,0 +1,6 @@
+# screencasters
+
+kazam                         user.bg_high
+eidete                        user.bg_high
+cmd:ffmpeg*x11grab*           user.bg_high
+cmd:avconv*x11grab*           user.bg_high

--- a/conf/simple.d/screencasters.conf
+++ b/conf/simple.d/screencasters.conf
@@ -2,5 +2,6 @@
 
 kazam                         user.bg_high
 eidete                        user.bg_high
+recordmydesktop               user.bg_high
 cmd:ffmpeg*x11grab*           user.bg_high
 cmd:avconv*x11grab*           user.bg_high

--- a/conf/simple.d/ubuntu.conf
+++ b/conf/simple.d/ubuntu.conf
@@ -1,0 +1,14 @@
+# Ubuntu-specific stuff
+
+# This file is created for elementary OS
+# and incorporates rules useful for ubuntu
+# and its derivatives
+
+# aptdaemon is a notorious background resource hog
+aptd                          daemon.bg
+
+# makes LiveUSBs, usually lengthy process
+usb-creator-*                 user.idle
+
+# ubuntu's notification system
+notify-osd                    user.ui

--- a/conf/simple.d/unity.conf
+++ b/conf/simple.d/unity.conf
@@ -1,0 +1,7 @@
+# Unity
+
+unity-panel-service           user.ui
+unity-2d-*                    user.ui
+unity-window-decorator        user.ui
+cmd:*/usr/lib/unity-lens-*    user.ui
+cmd:*/usr/lib/unity-scope-*   user.ui

--- a/conf/simple.d/video.conf
+++ b/conf/simple.d/video.conf
@@ -11,3 +11,5 @@ totem                         user.media
 kplayer                       user.media
 kmplayer                      user.media
 kaffeine                      user.media
+audience                      user.media
+xnoise                        user.media

--- a/conf/simple.d/xfce.conf
+++ b/conf/simple.d/xfce.conf
@@ -3,3 +3,6 @@
 xfwm4                         user.ui
 xfce4-panel                   user.ui
 xfdesktop                     user.ui
+
+# thumbnailer
+tumblerd                      user.bg_high

--- a/rules/gnome.lua
+++ b/rules/gnome.lua
@@ -8,7 +8,7 @@
 
 GnomeUI = {
   name = "GnomeUI",
-  re_basename = "metacity|compiz|gnome-panel|gtk-window-decorator|nautilus",
+  re_basename = "metacity|mutter|compiz|gtk-window-decorator|gnome-panel|gnome-shell|nautilus",
   --re_basename = "metacity",
   check = function(self, proc)
     local flag = ulatency.new_flag("user.ui")


### PR DESCRIPTION
Hi Daniel,

I've been working on integrating ulatencyd in elementary OS lately and decided to share the configs I wrote.

I've added added low-prio presets for bittorrent clients, miscellaneous presets of Ubuntu-specific stuff in a separate "ubuntu.conf" file, high-prio configs for screencasters (based on which one can write profiles for realtime video capture), a high-prio profile for D-bus daemon (tbh I haven't completely figured out what to do about it, so I've set it to user.bg_high for now), and "user.poison reason=memory" presets for GUI terminals which often have infinite scrollback which can gobble up the whole RAM in extreme cases.

In terms of DE support this pull request adds presets for Unity and elementary's Pantheon Shell and updates presets for GNOME to work with GNOME3 (though I haven't tested if GNOME Shell arranges processes in cgroups by default and if the workaround for gnome-panel should be applied here too). I've also expanded existing lists of audio and video players.

I'm looking forward to your feedback and hopefully getting this merged into master.
