### PR TITLE
Fix Lua access() calls

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -255,7 +255,7 @@ local function mkdirp(path)
     local parts = path:split("/")
     for i,v in ipairs(parts) do
       name = "/" .. table.concat(parts, "/", 1, i)
-      if posix.access(name, posix.R_OK) ~= 0 then
+      if posix.access(name, "r") ~= 0 then
         if posix.mkdir(name) ~= 0 then
           cg_log("can't create "..name)
           return false
@@ -477,7 +477,7 @@ end
 
 function CGroup:get_tasks()
   local t_file = self:path("tasks")
-  if posix.access(t_file, posix.R_OK) ~= 0 then
+  if posix.access(t_file, "r") ~= 0 then
     return {}
   end
   rv = {}
@@ -490,7 +490,7 @@ end
 function CGroup:has_tasks()
   local rv = false
   local t_file = self:path("tasks")
-  if posix.access(t_file, posix.R_OK) ~= 0 then
+  if posix.access(t_file, "r") ~= 0 then
     return false
   end
   for line in io.lines(t_file) do


### PR DESCRIPTION
Apparently there's no such thing as `posix.R_OK`. This patch replaces it with just "r". AFAICT "r" is also selected when passing `nil`, and that's maybe why it woked fine so far.
