### PR TITLE
Fix minimum blkio weight

### DIFF
--- a/conf/scheduler/20-desktop.lua
+++ b/conf/scheduler/20-desktop.lua
@@ -260,7 +260,7 @@ SCHEDULER_MAPPING_DESKTOP["blkio"] =
     name = "poison",
     label = { "user.poison", "user.poison.group" },
     cgroups_name = "psn_${pgrp}",
-    param = { ["blkio.weight"]="1" },
+    param = { ["blkio.weight"]="100" },
     adjust = function(cgroup, proc)
                 save_io_prio(proc, 7, ulatency.IOPRIO_CLASS_IDLE)
              end,
@@ -285,7 +285,7 @@ SCHEDULER_MAPPING_DESKTOP["blkio"] =
   },
   {
     name = "idle",
-    param = { ["blkio.weight"]="1" },
+    param = { ["blkio.weight"]="100" },
     label = { "daemon.idle", "user.idle" },
     adjust = function(cgroup, proc)
                 save_io_prio(proc, 5, ulatency.IOPRIO_CLASS_IDLE)

--- a/conf/scheduler/30-game.lua
+++ b/conf/scheduler/30-game.lua
@@ -175,7 +175,7 @@ SCHEDULER_MAPPING_GAME["blkio"] =
   },
   {
     name = "group",
-    param = { ["blkio.weight"]="1" },
+    param = { ["blkio.weight"]="100" },
     cgroups_name = "grp_${pgrp}",
     check = function(proc)
               return proc.pgrp > 0

--- a/conf/scheduler/30-single-task.lua
+++ b/conf/scheduler/30-single-task.lua
@@ -188,7 +188,7 @@ SCHEDULER_MAPPING_SINGLE_TASK["blkio"] =
   },
   { 
     name = "group",
-    param = { ["blkio.weight"]="1" },
+    param = { ["blkio.weight"]="100" },
     cgroups_name = "grp_${pgrp}",
     check = function(proc)
               return proc.pgrp > 0


### PR DESCRIPTION
The blkio weight range is 100..1000 on Linux versions before 3.2.0 and 10..1000 on 3.2.0. Currently ulatencyd uses 1 for poisonous and idle processes and makes them having no penalty on disk usage (at least here, since they stay with blkio.weight=500).
